### PR TITLE
Fix ToC items to match corresponding headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A curated list of awesome Web Components resources.
 - [Archive](#archive)
   - [Polyfills](#polyfills)
   - [History](#history)
-- [Who to follow](#who-to-follow)
+- [Who To Follow](#who-to-follow)
 - [Maintainers](#maintainers)
 - [License](#license)
 
@@ -540,17 +540,17 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [Form-associated custom elements](https://www.chromestatus.com/features/4708990554472448) - Feature in Chrome platform status.
 - [web-platform-tests](https://github.com/web-platform-tests/wpt/tree/master/custom-elements/form-associated)
 
-### Custom State Pseudo class
-
-- [Blink: Intent to implement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/CApU9QIu3TM)
-- [`ElementInternals`'s `states` property and the `:state()` pseudo class](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/custom-states-and-state-pseudo-class.md)
-
 ### Constructable Stylesheet Objects
 
 - [Specification Draft](https://wicg.github.io/construct-stylesheets/)
 - [web-platform-tests](https://github.com/web-platform-tests/wpt/blob/master/css/cssom/CSSStyleSheet-constructable.html)
 - [Explainer](https://github.com/WICG/construct-stylesheets/blob/gh-pages/explainer.md)
 - [Constructable Stylesheets](https://www.chromestatus.com/feature/5394843094220800) - Feature in Chrome platform status.
+
+### Custom State Pseudo class
+
+- [Blink: Intent to implement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/CApU9QIu3TM)
+- [`ElementInternals`'s `states` property and the `:state()` pseudo class](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/custom-states-and-state-pseudo-class.md)
 
 ## Miscellaneous
 


### PR DESCRIPTION
Fixed the following errors reported by the "Awesome Lint" checker:

```
ToC item "Constructable Stylesheet Objects" does not match corresponding heading "Custom State Pseudo class"
ToC item "Who to follow" does not match corresponding heading "Who To Follow"
  ```