### PR TITLE
Add element-js to list of class based libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 ### Class Based
 
 - [DNA](https://github.com/chialab/dna) - Progressive Web Components library.
+- [element-js](https://github.com/webtides/element-js) - Simple and lightweight base classes for web components with a beautiful API.
 - [FAST Element](https://github.com/microsoft/fast/tree/master/packages/web-components/fast-element) - Lightweight library for building performant, memory-efficient, standards-compliant Web Components.
 - [Forge Core](https://github.com/tyler-technologies-oss/forge-core) - Building blocks and utilities that are used when building Forge Web Components.
 - [Joist](https://github.com/joist-framework/joist) - Set of small libraries designed to add the bare minimum to web components to make you productive.


### PR DESCRIPTION
I would like to add our library to the list of class based libraries. We have been using it since 2017 and it is actively maintained.