### PR TITLE
Add @pionjs/pion

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [atomico](https://github.com/atomicojs/atomico) - Small library for the creation of interfaces based on web components using functions and hooks.
 - [Elemento](https://github.com/dsolimando/elemento) - A lightweight library for building functional web components using signals and Lit.
 - [haunted](https://github.com/matthewp/haunted) - React's Hooks API implemented for web components.
+- [pion](https://github.com/pionjs/pion) - React's Hooks API for web components with lit-html.
 - [hybrids](https://github.com/hybridsjs/hybrids) - UI library for creating Web Components with simple and functional API.
 - [Solid Element](https://github.com/solidjs/solid/tree/main/packages/solid-element) - Library that extends Solid adding Custom Web Components and extensions.
 


### PR DESCRIPTION
Adds [pion](https://github.com/pionjs/pion) — React's Hooks API for standard web components with lit-html.

Fork of [haunted](https://github.com/matthewp/haunted), actively maintained with full TypeScript support. Docs: https://pionjs.com · npm: https://npm.im/@pionjs/pion